### PR TITLE
Add Mailgun support

### DIFF
--- a/resources/config/shield.php
+++ b/resources/config/shield.php
@@ -7,7 +7,8 @@ return [
         'gitlab' => \Clarkeash\Shield\Services\GitLab::class,
         'stripe' => \Clarkeash\Shield\Services\Stripe::class,
         'zapier' => \Clarkeash\Shield\Services\Zapier::class,
-        'trello' => \Clarkeash\Shield\Services\Trello::class
+        'trello' => \Clarkeash\Shield\Services\Trello::class,
+        'mailgun' => \Clarkeash\Shield\Services\Mailgun::class,
     ],
 
     'services' => [
@@ -33,6 +34,10 @@ return [
         ],
         'trello' => [
             'app_secret' => 'your-app-secret'
-        ]
+        ],
+        'mailgun' => [
+            'token' => env('MAILGUN_SECRET', 'your-custom-webhook-token'),
+            'tolerance' => \Carbon\Carbon::SECONDS_PER_MINUTE * 5,
+        ],
     ]
 ];

--- a/src/Services/Mailgun.php
+++ b/src/Services/Mailgun.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Clarkeash\Shield\Services;
+
+use Illuminate\Http\Request;
+
+class Mailgun extends BaseService
+{
+    public function verify(Request $request): bool
+    {
+        $tolerance = config('shield.services.mailgun.tolerance', 60 * 5);
+        $timestamp = $request->input('timestamp');
+
+        if (
+            ! $request->isMethod('POST') ||
+            abs(time() - $timestamp) > $tolerance
+        ) {
+            return false;
+        }
+
+        $signature = $this->buildSignature(
+            $request->input('timestamp'),
+            $request->input('token')
+        );
+
+        return $signature === $request->input('signature');
+    }
+
+    public function headers(): array
+    {
+        return [];
+    }
+
+    /**
+     * Build the signature for verification
+     *
+     * @param string $timestamp
+     * @param string $token
+     * @return string
+     */
+    protected function buildSignature(string $timestamp, string $token)
+    {
+        return hash_hmac(
+            'sha256',
+            sprintf('%s%s', $timestamp, $token),
+            config('shield.services.mailgun.token')
+        );
+    }
+}

--- a/tests/Services/MailgunTest.php
+++ b/tests/Services/MailgunTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Clarkeash\Shield\Test\Services;
+
+use Carbon\Carbon;
+use Clarkeash\Shield\Contracts\Service;
+use Clarkeash\Shield\Services\Mailgun;
+use Clarkeash\Shield\Test\TestCase;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Assert;
+
+class MailgunTest extends TestCase
+{
+    /**
+     * @var Mailgun
+     */
+    protected $service;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->service = new Mailgun;
+    }
+
+    /** @test */
+    public function it_is_a_service()
+    {
+        Assert::assertInstanceOf(Service::class, new Mailgun);
+    }
+
+    /** @test */
+    public function it_can_verify_a_valid_request()
+    {
+        $token = 'raNd0mk3y';
+        $this->app['config']['shield.services.mailgun.token'] = $token;
+
+        // Build the signature for the request payload
+        $timestamp = Carbon::now()->timestamp;
+        $signature = $this->buildSignature($timestamp, $token);
+
+        $request = $this->request(json_encode([
+            'timestamp' => $timestamp,
+            'token' => $token,
+            'signature' => $signature,
+        ]));
+
+        $headers = [
+            'Content-Type' => 'application/json'
+        ];
+
+        $request->headers->add($headers);
+
+        Assert::assertTrue($this->service->verify($request));
+    }
+
+    /** @test */
+    public function it_will_not_verify_an_old_request()
+    {
+        $token = 'raNd0mk3y';
+        $tolerance = 60;
+
+        $this->app['config']['shield.services.mailgun.token'] = $token;
+        $this->app['config']['shield.services.mailgun.tolerance'] = $tolerance;
+
+        // Build the signature for the request payload
+        $timestamp = Carbon::now()->subSeconds($tolerance + 1)->timestamp;
+        $signature = $this->buildSignature($timestamp, $token);
+
+        $request = $this->request(json_encode([
+            'timestamp' => $timestamp,
+            'token' => $token,
+            'signature' => $signature,
+        ]));
+
+        $headers = [
+            'Content-Type' => 'application/json'
+        ];
+
+        $request->headers->add($headers);
+
+        Assert::assertFalse($this->service->verify($request));
+    }
+
+    /** @test */
+    public function it_will_not_verify_a_bad_request()
+    {
+        $token = 'good';
+        $this->app['config']['shield.services.mailgun.token'] = $token;
+
+        // Build the signature for the request payload
+        $timestamp = Carbon::now()->timestamp;
+        $signature = $this->buildSignature($timestamp, $token);
+
+        $request = $this->request(json_encode([
+            'timestamp' => $timestamp,
+            'token' => 'bad',
+            'signature' => $signature,
+        ]));
+
+        $headers = [
+            'Content-Type' => 'application/json'
+        ];
+
+        $request->headers->add($headers);
+
+        Assert::assertFalse($this->service->verify($request));
+    }
+
+    /** @test */
+    public function it_requires_a_post_request()
+    {
+        // Set up valid data
+        $token = 'raNd0mk3y';
+        $this->app['config']['shield.services.mailgun.token'] = $token;
+
+        // Build the signature for the request payload
+        $timestamp = Carbon::now()->timestamp;
+        $signature = $this->buildSignature($timestamp, $token);
+
+        $requestBody = json_encode([
+            'timestamp' => $timestamp,
+            'token' => $token,
+            'signature' => $signature,
+        ]);
+
+        $examples = ['GET', 'PUT', 'PATCH', 'DELETE', 'POST'];
+
+        foreach ($examples as $example) {
+
+            $request = Request::create('http://example.com', $example, [], [], [], [], $requestBody);
+            $request->headers->add([
+                'Content-Type' => 'application/json'
+            ]);
+
+            $assertion = $example === 'POST' ? 'assertTrue' : 'assertFalse';
+
+            Assert::$assertion(
+                $this->service->verify($request),
+                "Expected $example to $assertion, but it did not."
+            );
+        }
+    }
+
+    /** @test */
+    public function it_has_correct_headers_required()
+    {
+        Assert::assertArraySubset([], $this->service->headers());
+    }
+
+    protected function buildSignature($timestamp, $token)
+    {
+        return hash_hmac(
+            'sha256',
+            sprintf('%s%s', $timestamp, $token),
+            config('shield.services.mailgun.token')
+        );
+    }
+}


### PR DESCRIPTION
Provides a mailgun service for securing inbound email processing.

Note: Laravel provides `MAILGUN_SECRET` so I used that in the configuration provided.

See
https://documentation.mailgun.com/en/latest/user_manual.html#webhooks
for more information.