### PR TITLE
Add support for Bitbucket (via IP whitelisting)

### DIFF
--- a/resources/config/shield.php
+++ b/resources/config/shield.php
@@ -7,7 +7,8 @@ return [
         'gitlab' => \Clarkeash\Shield\Services\GitLab::class,
         'stripe' => \Clarkeash\Shield\Services\Stripe::class,
         'zapier' => \Clarkeash\Shield\Services\Zapier::class,
-        'trello' => \Clarkeash\Shield\Services\Trello::class
+        'trello' => \Clarkeash\Shield\Services\Trello::class,
+        'bitbucket' => \Clarkeash\Shield\Services\Bitbucket::class
     ],
 
     'services' => [
@@ -33,6 +34,14 @@ return [
         ],
         'trello' => [
             'app_secret' => 'your-app-secret'
+        ],
+        'bitbucket' => [
+            'allowed_ips' => [
+                '104.192.143.0/24',
+                '34.198.203.127',
+                '34.198.178.64',
+                '34.198.32.85'
+            ]
         ]
     ]
 ];

--- a/src/Services/Bitbucket.php
+++ b/src/Services/Bitbucket.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Clarkeash\Shield\Services;
+
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\IpUtils;
+
+class Bitbucket extends BaseService
+{
+    public function verify(Request $request): bool
+    {
+        return IpUtils::checkIp($request->ip(), config('shield.services.bitbucket.allowed_ips'));
+    }
+
+    public function headers(): array
+    {
+        return [];
+    }
+}

--- a/tests/Services/BitbucketTest.php
+++ b/tests/Services/BitbucketTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Clarkeash\Shield\Test\Services;
+
+use Clarkeash\Shield\Contracts\Service;
+use Clarkeash\Shield\Services\Bitbucket;
+use Clarkeash\Shield\Test\TestCase;
+use PHPUnit\Framework\Assert;
+
+class BitbucketTest extends TestCase
+{
+    /**
+     * @var Bitbucket
+     */
+    protected $service;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->service = new Bitbucket;
+    }
+
+    /** @test */
+    public function it_is_a_service()
+    {
+        Assert::assertInstanceOf(Service::class, new Bitbucket);
+    }
+
+    /** @test */
+    public function it_can_verify_a_valid_request()
+    {
+        $allowedIps = config('shield.services.bitbucket.allowed_ips');
+        $content = 'sample content';
+
+        foreach ($allowedIps as $ip) {
+            $request = $this->request($content, explode('/', $ip)[0]);
+
+            Assert::assertTrue($this->service->verify($request));
+        }
+    }
+
+    /** @test */
+    public function it_will_not_verify_a_bad_request()
+    {
+        $content = 'sample content';
+        $request = $this->request($content, '8.8.8.8');
+
+        Assert::assertFalse($this->service->verify($request));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,8 +27,8 @@ class TestCase extends TestBench
      *
      * @return Request
      */
-    protected function request($content = null)
+    protected function request($content = null, $ip = '')
     {
-        return Request::create('http://example.com', 'POST', [], [], [], [], $content);
+        return Request::create('http://example.com', 'POST', [], [], [], ['REMOTE_ADDR' => $ip], $content);
     }
 }


### PR DESCRIPTION
As far as I know the only way to validate webhooks coming from bitbucket is to check for the request IP address.

Please correct me if I'm wrong.

See the [documentation](https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html) for more.